### PR TITLE
More flexible

### DIFF
--- a/lib/generators/templates/jquery.remotipart.js
+++ b/lib/generators/templates/jquery.remotipart.js
@@ -31,7 +31,7 @@ jQuery(function ($) {
 					
 	                el.ajaxSubmit({
 	                    url: url,
-	                    dataType: 'script',
+	                    dataType: dataType,
 	                    beforeSend: function (xhr) {
 	                        el.trigger('ajax:loading', xhr);
 	                    },

--- a/lib/generators/templates/jquery.remotipart.js
+++ b/lib/generators/templates/jquery.remotipart.js
@@ -20,7 +20,7 @@ jQuery(function ($) {
                   name: "remotipart_submitted",
                   value: true
                 }))
-                .data('remotipartSubmitted', true);
+                .data('remotipartSubmitted', dataType);
 
 	            if (el.triggerAndReturn('ajax:before')) {
               if (dataType == 'script') {

--- a/lib/generators/templates/jquery.remotipart.js
+++ b/lib/generators/templates/jquery.remotipart.js
@@ -5,16 +5,29 @@ jQuery(function ($) {
 	     */
 	    callRemotipart: function () {
 	        var el      = this,
-	            url     = el.attr('action');
+	            url     = el.attr('action')
+              dataType = el.attr('data-type') || 'script';
 
 	        if (url === undefined) {
 	          throw "No URL specified for remote call (action must be present).";
 	        } else {
-	            if (el.triggerAndReturn('ajax:before')) {
+              // Since iframe-submitted form is submitted normal-style and cannot set custom headers,
+              // we'll add a custom hidden input to keep track and let the server know this was still
+              // an AJAX form, we'll also make it easy to tell from our jQuery element object.
+              el
+                .append($('<input />', {
+                  type: "hidden",
+                  name: "remotipart_submitted",
+                  value: true
+                }))
+                .data('remotipartSubmitted', true);
 
+	            if (el.triggerAndReturn('ajax:before')) {
+              if (dataType == 'script') {
 		          	url = url.split('?'); // split on GET params
-					if(url[0].substr(-3) != '.js') url[0] += '.js'; // force rails to respond to respond to the request with :format = js
-					url = url.join('?'); // join on GET params
+					      if(url[0].substr(-3) != '.js') url[0] += '.js'; // force rails to respond to respond to the request with :format = js
+					      url = url.join('?'); // join on GET params
+              }
 					
 	                el.ajaxSubmit({
 	                    url: url,

--- a/lib/remotipart.rb
+++ b/lib/remotipart.rb
@@ -1,9 +1,12 @@
 module Remotipart
   def remotipart_response(options = {}, &block)
-    return yield unless params[:remotipart_submitted]
-    response.content_type = Mime::HTML
     content = with_output_buffer(&block)
-    text_area_tag('remotipart_response', String.new(content), options)
+    if params[:remotipart_submitted]
+      response.content_type = Mime::HTML
+      text_area_tag('remotipart_response', String.new(content), options)
+    else
+      content
+    end
   end
 end
 

--- a/lib/remotipart.rb
+++ b/lib/remotipart.rb
@@ -1,5 +1,6 @@
 module Remotipart
   def remotipart_response(options = {}, &block)
+    return yield unless params[:remotipart_submitted]
     response.content_type = Mime::HTML
     content = with_output_buffer(&block)
     text_area_tag('remotipart_response', String.new(content), options)


### PR DESCRIPTION
I made some changes to make remotipart much more agnostic and flexible. Instead of making remotipart only able to do 'script' data-type requests, it now respects the `data-type` attribute on the remote forms, defaulting to 'script'.

It also now adds a hidden field before `ajaxSubmit` to indicate the form was `remotipart_submitted`. This way, it's no longer necessary to have completely separate responses and js.erb templates for the multipart forms. `remotipart_response` was modified to yield the javascript directly unless the form was `remotipart_submitted`. 

And finally, since it is not possible, from within the context of the jQuery ajax callback hooks, to tell whether or not the ajax request was submitted via remotipart, or what data-type was requested, I added `el.data('remotipartSubmitted', dataType);` to the submitted form, which can then be retrieved in the ajax callbacks.

Please see [Rails 3 Remote Links and Forms Part 2: Data-type](http://www.alfajango.com/blog/rails-3-remote-links-and-forms-data-type-with-jquery/)for more info about using data-types other than 'script', and why these changes were needed.
