### PR TITLE
jQuery live method has been removed from version 1.9

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -62,7 +62,7 @@
     }
   };
 
-  $('form').live('ajax:aborted:file', function(){
+  $(document).on('ajax:aborted:file', 'form', function(){
     var form = $(this);
 
     // Only need to setup form and make form bindings once.


### PR DESCRIPTION
jQuery live method has been removed from version 1.9, so I replaced it with $(document).on
